### PR TITLE
Add .gitignore to keep "git status" clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/Gauche-makiki.gpd
+/Makefile
+/VERSION
+/config.log


### PR DESCRIPTION
PS. With git being a popular version control, perhaps `gauche-package generate` should add this file automatically (maybe with an option to turn it off)